### PR TITLE
Set trait colors in the chat when using the light theme

### DIFF
--- a/styles/light.css
+++ b/styles/light.css
@@ -1,228 +1,252 @@
 @font-face {
-  font-family: "Exo2";
-  src: local("Exo2"), url("../fonts/Exo2.woff2") format("woff2 supports variations"),
-    url("../fonts/Exo2.woff2") format("woff2-variations");
-  font-weight: 350;
-  font-style: normal;
+    font-family: "Exo2";
+    src: local("Exo2"),
+        url("../fonts/Exo2.woff2") format("woff2 supports variations"),
+        url("../fonts/Exo2.woff2") format("woff2-variations");
+    font-weight: 350;
+    font-style: normal;
 }
 
 @font-face {
-  font-family: "Exo2";
-  src: local("Exo2"), url("../fonts/Exo2.woff2") format("woff2 supports variations"),
-    url("../fonts/Exo2.woff2") format("woff2-variations");
-  font-weight: 600;
-  font-style: normal;
+    font-family: "Exo2";
+    src: local("Exo2"),
+        url("../fonts/Exo2.woff2") format("woff2 supports variations"),
+        url("../fonts/Exo2.woff2") format("woff2-variations");
+    font-weight: 600;
+    font-style: normal;
 }
 
 @font-face {
-  font-family: "Exo2";
-  src: local("Exo2-Italic"), url("../fonts/Exo2-Italic.woff2") format("woff2 supports variations"),
-    url("../fonts/Exo2-Italic.woff2") format("woff2-variations");
-  font-weight: 350;
-  font-style: italic;
+    font-family: "Exo2";
+    src: local("Exo2-Italic"),
+        url("../fonts/Exo2-Italic.woff2") format("woff2 supports variations"),
+        url("../fonts/Exo2-Italic.woff2") format("woff2-variations");
+    font-weight: 350;
+    font-style: italic;
 }
 
 @font-face {
-  font-family: "Exo2";
-  src: local("Exo2-Italic"), url("../fonts/Exo2-Italic.woff2") format("woff2 supports variations"),
-    url("../fonts/Exo2-Italic.woff2") format("woff2-variations");
-  font-weight: 600;
-  font-style: italic;
+    font-family: "Exo2";
+    src: local("Exo2-Italic"),
+        url("../fonts/Exo2-Italic.woff2") format("woff2 supports variations"),
+        url("../fonts/Exo2-Italic.woff2") format("woff2-variations");
+    font-weight: 600;
+    font-style: italic;
 }
 
 @font-face {
-  font-family: "Saira";
-  src: local("Saira"), url("../fonts/Saira.woff2") format("woff2 supports variations"),
-    url("../fonts/Saira.woff2") format("woff2-variations");
-  font-weight: 350;
-  font-style: normal;
+    font-family: "Saira";
+    src: local("Saira"),
+        url("../fonts/Saira.woff2") format("woff2 supports variations"),
+        url("../fonts/Saira.woff2") format("woff2-variations");
+    font-weight: 350;
+    font-style: normal;
 }
 
 @font-face {
-  font-family: "Saira";
-  src: local("Saira"), url("../fonts/Saira.woff2") format("woff2 supports variations"),
-    url("../fonts/Saira.woff2") format("woff2-variations");
-  font-weight: 600;
-  font-style: normal;
+    font-family: "Saira";
+    src: local("Saira"),
+        url("../fonts/Saira.woff2") format("woff2 supports variations"),
+        url("../fonts/Saira.woff2") format("woff2-variations");
+    font-weight: 600;
+    font-style: normal;
 }
 
 @font-face {
-  font-family: "Saira";
-  src: local("Saira-Italic"), url("../fonts/Saira-Italic.woff2") format("woff2 supports variations"),
-    url("../fonts/Saira-Italic.woff2") format("woff2-variations");
-  font-weight: 350;
-  font-style: italic;
+    font-family: "Saira";
+    src: local("Saira-Italic"),
+        url("../fonts/Saira-Italic.woff2") format("woff2 supports variations"),
+        url("../fonts/Saira-Italic.woff2") format("woff2-variations");
+    font-weight: 350;
+    font-style: italic;
 }
 
 @font-face {
-  font-family: "Exo2";
-  src: local("Saira-Italic"), url("../fonts/Saira-Italic.woff2") format("woff2 supports variations"),
-    url("../fonts/Saira-Italic.woff2") format("woff2-variations");
-  font-weight: 600;
-  font-style: italic;
+    font-family: "Exo2";
+    src: local("Saira-Italic"),
+        url("../fonts/Saira-Italic.woff2") format("woff2 supports variations"),
+        url("../fonts/Saira-Italic.woff2") format("woff2-variations");
+    font-weight: 600;
+    font-style: italic;
+}
+
+.app.sheet.actor.character,
+.sidebar-tab.chat-sidebar {
+    /* Color Definitions */
+    --color-bg-trait: #2d4f6a;
+    --color-border-trait: #9edae6;
+
+    /** Proficiency ranks */
+    --color-proficiency-trained: #2c4e69;
+    --color-proficiency-expert: #5b3a96;
+    --color-proficiency-master: #3a7b59;
+    --color-proficiency-legendary: #98503d;
 }
 
 .app.sheet.actor.character section.window-content form.crb-style {
-  /* Color Definitions */
-  --color-bg-trait: #2d4f6a;
-  --color-border-trait: #9edae6;
-  --c-primary: #2c4e69; /* teal */
-  --c-secondary: #5b3a96; /* purple */
-  --c-tertiary: #b9519e; /* pink */
-  --c-accent: #9dd9e5; /* baby blue */
-  --c-emphasis: #ec2026; /* red */
-  --c-secondary-light: hsl(262, 44%, calc(41% / 0.7));
-  --c-tertiary-light: hsl(316, calc(43% / 0.7), calc(52% / 0.6));
-  --c-accent-light: hsl(190, 58%, calc(76% / 0.7));
-  --c-primary-dark: hsl(207, 41%, calc(29% / 1.7));
-  --c-tertiary-dark: hsl(316, 43%, calc(52% / 1.2));
+    /* Color Definitions */
+    --c-primary: #2c4e69; /* teal */
+    --c-secondary: #5b3a96; /* purple */
+    --c-tertiary: #b9519e; /* pink */
+    --c-accent: #9dd9e5; /* baby blue */
+    --c-emphasis: #ec2026; /* red */
+    --c-secondary-light: hsl(262, 44%, calc(41% / 0.7));
+    --c-tertiary-light: hsl(316, calc(43% / 0.7), calc(52% / 0.6));
+    --c-accent-light: hsl(190, 58%, calc(76% / 0.7));
+    --c-primary-dark: hsl(207, 41%, calc(29% / 1.7));
+    --c-tertiary-dark: hsl(316, 43%, calc(52% / 1.2));
 
-  /* Font Overrides */
-  --serif: Saira, sans-serif;
-  --body-serif: Exo2, sans-serif;
+    /* Font Overrides */
+    --serif: Saira, sans-serif;
+    --body-serif: Exo2, sans-serif;
 
-  /* Color Overrides */
-  --sidebar-title: var(--c-accent);
-  --sidebar-label: var(--c-tertiary-light);
-  --color-pf-primary: var(--c-primary);
-  --color-pf-secondary: var(--c-secondary-light);
-  --color-pf-tertiary: var(--c-tertiary-light);
-  --primary: var(--c-primary);
-  --sub: #576293;
-  --alt: #3a7b59;
-  --color-pf-alternate: var(--alt);
-  --bg-dark: #b0dfe8;
+    /* Color Overrides */
+    --sidebar-title: var(--c-accent);
+    --sidebar-label: var(--c-tertiary-light);
+    --color-pf-primary: var(--c-primary);
+    --color-pf-secondary: var(--c-secondary-light);
+    --color-pf-tertiary: var(--c-tertiary-light);
+    --primary: var(--c-primary);
+    --sub: #576293;
+    --alt: #3a7b59;
+    --color-pf-alternate: var(--alt);
+    --bg-dark: #b0dfe8;
 
-  background: url("../assets/theme/light/blue-gradient-bottom.webp"), #e2e7e9;
-  background-size: 100% 5.625rem, auto;
-  background-repeat: repeat-x, repeat;
+    background: url("../assets/theme/light/blue-gradient-bottom.webp"), #e2e7e9;
+    background-size: 100% 5.625rem, auto;
+    background-repeat: repeat-x, repeat;
 
-  .pf-rank[data-rank="1"] {
-    background: var(--c-primary);
-  }
-
-  .pf-rank[data-rank="2"] {
-    background: var(--c-secondary);
-  }
-
-  .pf-rank[data-rank="3"] {
-    background: #3a7b59;
-  }
-
-  .pf-rank[data-rank="4"] {
-    background: #98503d;
-  }
-
-  div.data-value {
-    input {
-      position: relative;
-      top: -0.3rem;
-    }
-  }
-
-  > header.char-header .char-level .level {
-    filter: hue-rotate(270deg) brightness(1.6);
-    input {
-      font-size: 1rem;
-      position: relative;
-      top: -0.2rem;
-    }
-  }
-
-  ol.spell-list > li.header-row {
-    background-color: rgba(58, 123, 89, 0.1);
-  }
-
-  ul.items > li:nth-of-type(even),
-  ol.feats-list li.slot:nth-child(odd),
-  ol.spell-list li:nth-child(odd):not(.header-row) {
-    background-color: rgba(113, 127, 127, 0.1);
-  }
-
-  > nav.sheet-navigation {
-    z-index: 2;
-    filter: brightness(1.2);
-    background: linear-gradient(to right, var(--c-primary), var(--c-primary));
-
-    .item {
-      box-shadow: 0 0 0 1px var(--color-pf-tertiary), 0 0 0 2px var(--c-accent), inset 0 0 4px rgba(0, 0, 0, 0.25);
-      &.active {
-        background-image: radial-gradient(circle at center, var(--c-secondary), var(--c-secondary));
-        box-shadow: 0 0 0 1px var(--color-pf-tertiary), 0 0 0 2px var(--c-accent), inset 0 0 4px rgba(0, 0, 0, 0.25),
-          0 0 8px var(--color-pf-tertiary);
-      }
-
-      &:hover,
-      &.active:hover {
-        background-image: radial-gradient(circle at center, var(--c-secondary), var(--c-tertiary));
-        box-shadow: 0 0 0 1px var(--color-pf-tertiary), 0 0 0 2px var(--c-accent), inset 0 0 4px rgba(0, 0, 0, 0.25),
-          0 0 8px var(--color-pf-tertiary);
-      }
-    }
-  }
-
-  > .sheet-body .sheet-content .tab {
-    &.active.character .subsection.details .image-container .actor-image {
-      box-shadow: 0 0 0 1px #888e91, 0 0 0 2px #d0e0e2, 0 0 0 3px var(--c-accent), inset 0 0 8px rgba(0, 0, 0, 0.5),
-        0 0 8px black;
-    }
-  }
-
-  > aside {
-    --color-pf-secondary: var(--c-tertiary-dark);
-    filter: brightness(1.2);
-    background-image: linear-gradient(
-      to right,
-      var(--c-accent),
-      var(--c-primary) 3%,
-      var(--c-primary) 97%,
-      var(--c-accent)
-    );
-    background-repeat: repeat;
-
-    &::before {
-      content: "";
-      float: left;
-      opacity: 1;
-      background-image: url("../assets/sf-logo.webp");
-      background-size: contain;
-      width: 234px;
-      height: 56px;
-      position: relative;
-      left: -0.5rem;
-      top: 0;
-    }
-
-    .sidebar {
-      select {
-        border: 1px solid var(--c-accent);
-      }
-      .data-value h2 {
-        color: var(--c-tertiary-light);
-      }
-      a.modifier {
-        color: var(--c-accent-light);
-        text-decoration: underline var(--c-accent-light);
-      }
-      button {
-        color: var(--c-emphasis);
-        background: var(--c-accent-light);
-      }
-      .hitpoints .hp-big .container.current-hp {
-        background-image: linear-gradient(to right, var(--c-primary-dark), var(--c-primary), var(--c-primary-dark));
-      }
-      .armor-class {
-        .ac {
-          filter: hue-rotate(65deg) brightness(1.6);
+    div.data-value {
+        input {
+            position: relative;
+            top: -0.3rem;
         }
-        .shield.hp {
-          filter: hue-rotate(225deg) brightness(1.6);
-        }
-      }
     }
 
-    img.logo {
-      display: none;
+    > header.char-header .char-level .level {
+        filter: hue-rotate(270deg) brightness(1.6);
+        input {
+            font-size: 1rem;
+            position: relative;
+            top: -0.2rem;
+        }
     }
-  }
+
+    ol.spell-list > li.header-row {
+        background-color: rgba(58, 123, 89, 0.1);
+    }
+
+    ul.items > li:nth-of-type(even),
+    ol.feats-list li.slot:nth-child(odd),
+    ol.spell-list li:nth-child(odd):not(.header-row) {
+        background-color: rgba(113, 127, 127, 0.1);
+    }
+
+    > nav.sheet-navigation {
+        z-index: 2;
+        filter: brightness(1.2);
+        background: linear-gradient(
+            to right,
+            var(--c-primary),
+            var(--c-primary)
+        );
+
+        .item {
+            box-shadow: 0 0 0 1px var(--color-pf-tertiary),
+                0 0 0 2px var(--c-accent), inset 0 0 4px rgba(0, 0, 0, 0.25);
+            &.active {
+                background-image: radial-gradient(
+                    circle at center,
+                    var(--c-secondary),
+                    var(--c-secondary)
+                );
+                box-shadow: 0 0 0 1px var(--color-pf-tertiary),
+                    0 0 0 2px var(--c-accent), inset 0 0 4px rgba(0, 0, 0, 0.25),
+                    0 0 8px var(--color-pf-tertiary);
+            }
+
+            &:hover,
+            &.active:hover {
+                background-image: radial-gradient(
+                    circle at center,
+                    var(--c-secondary),
+                    var(--c-tertiary)
+                );
+                box-shadow: 0 0 0 1px var(--color-pf-tertiary),
+                    0 0 0 2px var(--c-accent), inset 0 0 4px rgba(0, 0, 0, 0.25),
+                    0 0 8px var(--color-pf-tertiary);
+            }
+        }
+    }
+
+    > .sheet-body .sheet-content .tab {
+        &.active.character .subsection.details .image-container .actor-image {
+            box-shadow: 0 0 0 1px #888e91, 0 0 0 2px #d0e0e2,
+                0 0 0 3px var(--c-accent), inset 0 0 8px rgba(0, 0, 0, 0.5),
+                0 0 8px black;
+        }
+    }
+
+    > aside {
+        --color-pf-secondary: var(--c-tertiary-dark);
+        filter: brightness(1.2);
+        background-image: linear-gradient(
+            to right,
+            var(--c-accent),
+            var(--c-primary) 3%,
+            var(--c-primary) 97%,
+            var(--c-accent)
+        );
+        background-repeat: repeat;
+
+        &::before {
+            content: "";
+            float: left;
+            opacity: 1;
+            background-image: url("../assets/sf-logo.webp");
+            background-size: contain;
+            width: 234px;
+            height: 56px;
+            position: relative;
+            left: -0.5rem;
+            top: 0;
+        }
+
+        .sidebar {
+            select {
+                border: 1px solid var(--c-accent);
+            }
+            .data-value h2 {
+                color: var(--c-tertiary-light);
+            }
+            a.modifier {
+                color: var(--c-accent-light);
+                text-decoration: underline var(--c-accent-light);
+            }
+            button {
+                color: var(--c-emphasis);
+                background: var(--c-accent-light);
+            }
+            .hitpoints .hp-big .container.current-hp {
+                background-image: linear-gradient(
+                    to right,
+                    var(--c-primary-dark),
+                    var(--c-primary),
+                    var(--c-primary-dark)
+                );
+            }
+            .armor-class {
+                .ac {
+                    filter: hue-rotate(65deg) brightness(1.6);
+                }
+                .shield.hp {
+                    filter: hue-rotate(225deg) brightness(1.6);
+                }
+            }
+        }
+
+        img.logo {
+            display: none;
+        }
+    }
 }


### PR DESCRIPTION
Also formats the stylesheet and moves setting the proficiency colors to css variables. Hide whitespace when viewing the diff to get a good view of the actual changes. I didn't set the primary/alt colors yet since I'm not 100% sure about those yet.

![image](https://github.com/user-attachments/assets/94f4cf4c-3aaa-4992-bbc4-a5a53650d7cb)


