### PR TITLE
Release 6.2

### DIFF
--- a/module.json
+++ b/module.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/TikaelSol/starfinder-field-test",
     "manifest": "https://github.com/TikaelSol/starfinder-field-test/releases/download/Latest/module.json",
     "download": "https://github.com/TikaelSol/starfinder-field-test/releases/download/Latest/starfinder-field-test-for-pf2e.zip",
-    "version": "6.1.1",
+    "version": "6.2",
     "compatibility": {
         "minimum": "12",
         "verified": "12"
@@ -16,7 +16,7 @@
                 "type": "system",
                 "manifest": "https://github.com/foundryvtt/pf2e/releases/latest/download/system.json",
                 "compatibility": {
-                    "minimum": "6.2.2"
+                    "minimum": "6.3.2"
                 }
             }
         ]

--- a/module.json
+++ b/module.json
@@ -16,7 +16,7 @@
                 "type": "system",
                 "manifest": "https://github.com/foundryvtt/pf2e/releases/latest/download/system.json",
                 "compatibility": {
-                    "minimum": "6.3.2"
+                    "minimum": "6.3.1"
                 }
             }
         ]


### PR DESCRIPTION
(ammalagonc) Brush up Vitality Network Effect
(ammalagonc) Fix action cost for Get Down and Warning Spray feats
(ammalagonc) Update Shotalashu Armor localization
(CarlosFdez) Add build and extract packs script
(CarlosFdez) Apply trait style to item and chat for all styles
(CarlosFdez) Fix feat type of augmented body and weapon group of machine gun
(CarlosFdez) Set project to use the Apache License
(CarlosFdez) Set trait colors in the chat when using the light theme
(DocSchlock) Fix typo in Brutal Anatomy rule elements
(LiftVortex) Add high copntrast theme
(pedrogrullada) Add critical specialization effects to localization file
(pedrogrullada) Add note to Graviton-Attuned Solar Weapon Strike
(pedrogrullada) Grant proficiency and critical specialization with Envoy Weapon Expertise
(pedrogrullada) Make spell chips not auto-destroy
(SpartanCPA) Add mental immunity to Repair Drone
(TikaelSol) Fix selectors on Hardlight Handwraps
(TikaelSol) Fix Solar Weapon damage when photon attuned and predicates for Twin Solar Weapon