### PR TITLE
Change Fabricator to a Skill Feat as intended

### DIFF
--- a/packs/feats/Fabricator_5qfJ8RzeTe5ucjf1.json
+++ b/packs/feats/Fabricator_5qfJ8RzeTe5ucjf1.json
@@ -20,7 +20,10 @@
     },
     "traits": {
       "otherTags": [],
-      "value": [],
+      "value": [
+        "general",
+        "skill"
+      ],
       "rarity": "common"
     },
     "publication": {
@@ -32,7 +35,7 @@
     "level": {
       "value": 1
     },
-    "category": "general",
+    "category": "skill",
     "onlyLevel1": false,
     "maxTakable": 1,
     "actionType": {


### PR DESCRIPTION
Per Page 150, Fabricator is a Skill Feat, not a General Feat.