### PR TITLE
Include special resource in vitality network and fix the description

### DIFF
--- a/packs/class-features/Vitality_Network_Mzj0Ynn3u8D3qkS5.json
+++ b/packs/class-features/Vitality_Network_Mzj0Ynn3u8D3qkS5.json
@@ -6,9 +6,13 @@
   "system": {
     "description": {
       "gm": "",
-      "value": "<p>Your soul supports a network of magical energy that connects and heals those in your bond. Your vitality network has a maximum capacity equal to 6 + 4 Hit Points per mystic level. You gain the @UUID[Compendium.starfinder-field-test-for-pf2e.actions.Item.y9tYChycW6xcdT7J]{Transfer Vitality} action that you can use to take Hit Points out of your network and into yourself or your allies as healing.</p><p>Life or death situations help strengthen your bonds with your allies. At the start of each turn in combat, when you regain actions, your vitality network regains 4 Hit Points; if you are master in your connection skill, it regains 6 Hit Points instead; if you are legendary, it regains 8 Hit Points. Your vitality network regains an amount of Hit Points equal to double your level plus your Wisdom modifier when you use the Refocus action. When you Refocus, your vitality network regains all its Hit Points.</p><p>@UUID[Compendium.starfinder-field-test-for-pf2e.conditions.Item.R0mn1iC3nYvDVKhd]{Effect: Vitality Network}</p>"
+      "value": "<p>Your soul supports a network of magical energy that connects and heals those in your bond. Your vitality network has a maximum capacity equal to 6 + 4 Hit Points per mystic level. You gain the @UUID[Compendium.starfinder-field-test-for-pf2e.actions.Item.y9tYChycW6xcdT7J]{Transfer Vitality} action that you can use to take Hit Points out of your network and into yourself or your allies as healing.</p><p>Life or death situations help strengthen your bonds with your allies. At the start of each turn in combat, when you regain actions, your vitality network regains 4 Hit Points; if you are master in your connection skill, it regains 6 Hit Points instead; if you are legendary, it regains 8 Hit Points. When you Refocus, your vitality network regains all its Hit Points.</p>"
     },
     "rules": [
+      {
+        "key": "SpecialResource",
+        "max": "6 + @actor.level * 4"
+      },
       {
         "key": "GrantItem",
         "uuid": "Compendium.starfinder-field-test-for-pf2e.actions.Item.y9tYChycW6xcdT7J"
@@ -60,11 +64,11 @@
   },
   "_stats": {
     "systemId": "pf2e",
-    "systemVersion": "6.4.1",
+    "systemVersion": "6.8.4",
     "coreVersion": "12.331",
     "createdTime": 1696480118345,
-    "modifiedTime": 1729301874851,
-    "lastModifiedBy": "HfiqVTKP7yuQgALu",
+    "modifiedTime": 1738051186478,
+    "lastModifiedBy": "GlF0nz95AKCs4I2s",
     "compendiumSource": null,
     "duplicateSource": null
   },


### PR DESCRIPTION
The previous last sentence referring to HP equal to double your level + wisdom was still there, even though its supposed to be replaced.