### PR TITLE
Add witchwarper class dc increases

### DIFF
--- a/packs/class-features/Expert_Spellcaster__Witchwarper__SIfwdlRHf4vDYe9B.json
+++ b/packs/class-features/Expert_Spellcaster__Witchwarper__SIfwdlRHf4vDYe9B.json
@@ -1,0 +1,83 @@
+{
+  "img": "icons/sundries/books/book-backed-silver-gold.webp",
+  "name": "Expert Spellcaster (Witchwarper)",
+  "system": {
+    "actionType": {
+      "value": "passive"
+    },
+    "actions": {
+      "value": null
+    },
+    "category": "classfeature",
+    "description": {
+      "value": "<p>Extended practice of magic has improved your capabilities. Your proficiency ranks for class DC, spell attack modifier, and spell DC increase to expert.</p>",
+      "gm": ""
+    },
+    "level": {
+      "value": 7
+    },
+    "prerequisites": {
+      "value": []
+    },
+    "publication": {
+      "license": "ORC",
+      "remaster": true,
+      "title": "Pathfinder Player Core",
+      "authors": ""
+    },
+    "rules": [
+      {
+        "key": "ActiveEffectLike",
+        "mode": "override",
+        "path": "system.proficiencies.classDCs.witchwarper.rank",
+        "value": 2
+      }
+    ],
+    "subfeatures": {
+      "proficiencies": {
+        "spellcasting": {
+          "rank": 2,
+          "attribute": null
+        }
+      },
+      "senses": {},
+      "suppressedFeatures": []
+    },
+    "traits": {
+      "rarity": "common",
+      "value": [
+        "witchwarper"
+      ],
+      "otherTags": []
+    },
+    "slug": "expert-spellcaster-witchwarper",
+    "_migration": {
+      "version": 0.935,
+      "previous": null
+    },
+    "onlyLevel1": false,
+    "maxTakable": 1,
+    "location": null
+  },
+  "type": "feat",
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "coreVersion": "12.331",
+    "systemId": "pf2e",
+    "systemVersion": "6.10.2",
+    "createdTime": 1742889885971,
+    "modifiedTime": 1742890455461,
+    "lastModifiedBy": "RPzJkeziZBD7sbya"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "RPzJkeziZBD7sbya": 3
+  },
+  "flags": {},
+  "_id": "SIfwdlRHf4vDYe9B",
+  "sort": 2300000,
+  "_key": "!items!SIfwdlRHf4vDYe9B"
+}

--- a/packs/class-features/Master_Spellcaster__Witchwarper__tSisqFztXZD0ZiF9.json
+++ b/packs/class-features/Master_Spellcaster__Witchwarper__tSisqFztXZD0ZiF9.json
@@ -1,0 +1,83 @@
+{
+  "img": "icons/skills/trades/academics-book-study-purple.webp",
+  "name": "Master Spellcaster (Witchwarper)",
+  "system": {
+    "actionType": {
+      "value": "passive"
+    },
+    "actions": {
+      "value": null
+    },
+    "category": "classfeature",
+    "description": {
+      "value": "<p>Your spells are among the most potent across all possible worlds. Your proficiency ranks for class DC, spell attack modifier, and spell DC increase to master.</p>",
+      "gm": ""
+    },
+    "level": {
+      "value": 15
+    },
+    "prerequisites": {
+      "value": []
+    },
+    "publication": {
+      "license": "ORC",
+      "remaster": true,
+      "title": "Pathfinder Player Core",
+      "authors": ""
+    },
+    "rules": [
+      {
+        "key": "ActiveEffectLike",
+        "mode": "override",
+        "path": "system.proficiencies.classDCs.witchwarper.rank",
+        "value": 3
+      }
+    ],
+    "subfeatures": {
+      "proficiencies": {
+        "spellcasting": {
+          "rank": 3,
+          "attribute": null
+        }
+      },
+      "senses": {},
+      "suppressedFeatures": []
+    },
+    "traits": {
+      "rarity": "common",
+      "value": [
+        "witchwarper"
+      ],
+      "otherTags": []
+    },
+    "slug": "master-spellcaster-witchwarper",
+    "_migration": {
+      "version": 0.935,
+      "previous": null
+    },
+    "onlyLevel1": false,
+    "maxTakable": 1,
+    "location": null
+  },
+  "type": "feat",
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "coreVersion": "12.331",
+    "systemId": "pf2e",
+    "systemVersion": "6.10.2",
+    "createdTime": 1742890365835,
+    "modifiedTime": 1742890479868,
+    "lastModifiedBy": "RPzJkeziZBD7sbya"
+  },
+  "effects": [],
+  "folder": null,
+  "ownership": {
+    "default": 0,
+    "RPzJkeziZBD7sbya": 3
+  },
+  "flags": {},
+  "_id": "tSisqFztXZD0ZiF9",
+  "sort": 200000,
+  "_key": "!items!tSisqFztXZD0ZiF9"
+}

--- a/packs/classes/Witchwarper_lyPoetdmvTRyjsSM.json
+++ b/packs/classes/Witchwarper_lyPoetdmvTRyjsSM.json
@@ -78,12 +78,6 @@
         "name": "Advanced Paradox",
         "level": 7
       },
-      "Tcal0": {
-        "uuid": "Compendium.pf2e.classfeatures.Item.cD3nSupdCvONuHiE",
-        "img": "icons/sundries/books/book-backed-silver-gold.webp",
-        "name": "Expert Spellcaster",
-        "level": 7
-      },
       "qLNWQ": {
         "uuid": "Compendium.pf2e.classfeatures.Item.70jqXP2eS4tRZ0Ok",
         "img": "systems/pf2e/icons/features/classes/magical-fortitude.webp",
@@ -126,12 +120,6 @@
         "name": "Weapon Specialization",
         "level": 13
       },
-      "JYtuZ": {
-        "uuid": "Compendium.pf2e.classfeatures.Item.l1InYvhnQSz6Ucxc",
-        "img": "icons/skills/trades/academics-book-study-purple.webp",
-        "name": "Master Spellcaster",
-        "level": 15
-      },
       "mlJUP": {
         "uuid": "Compendium.pf2e.classfeatures.Item.Hfaa7TuLn3nE8lr3",
         "img": "icons/sundries/books/book-open-purple.webp",
@@ -155,6 +143,18 @@
         "img": "modules/starfinder-field-test-for-pf2e/art/icons/abilities/blue%20energy%20pulse.webp",
         "name": "Quantum Pulse",
         "level": 1
+      },
+      "PrmdB": {
+        "uuid": "Compendium.starfinder-field-test-for-pf2e.class-features.Item.SIfwdlRHf4vDYe9B",
+        "img": "icons/sundries/books/book-backed-silver-gold.webp",
+        "name": "Expert Spellcaster (Witchwarper)",
+        "level": 7
+      },
+      "Dfz16": {
+        "uuid": "Compendium.starfinder-field-test-for-pf2e.class-features.Item.tSisqFztXZD0ZiF9",
+        "img": "icons/skills/trades/academics-book-study-purple.webp",
+        "name": "Master Spellcaster (Witchwarper)",
+        "level": 15
       }
     },
     "hp": 8,
@@ -259,10 +259,10 @@
     "duplicateSource": null,
     "coreVersion": "12.331",
     "systemId": "pf2e",
-    "systemVersion": "6.6.1",
+    "systemVersion": "6.10.2",
     "createdTime": 1721443704204,
-    "modifiedTime": 1730802020223,
-    "lastModifiedBy": "jWraEZiHJiAiiaaD"
+    "modifiedTime": 1742892447473,
+    "lastModifiedBy": "RPzJkeziZBD7sbya"
   },
   "_key": "!items!lyPoetdmvTRyjsSM"
 }


### PR DESCRIPTION
Closes https://github.com/TikaelSol/starfinder-field-test/issues/230

Legendary doesn't bump class dc for some reason. Let me know if I did this wrong. Foundry tried to update the sort property of every single class feature in that folder.