### PR TITLE
Fix Get 'Em! Ephemeral effect not working properly when localized

### DIFF
--- a/packs/actions/Get__Em__FXlhxST6fuaFt3Nh.json
+++ b/packs/actions/Get__Em__FXlhxST6fuaFt3Nh.json
@@ -11,19 +11,20 @@
       {
         "key": "AdjustModifier",
         "selector": "damage",
-        "slug": "get-em-lead-by-example",
+        "predicate": [
+          "self:effect:get-em-lead-by-example"
+        ],
         "mode": "add",
         "value": "floor(@actor.system.abilities.cha.mod/2)"
       }
     ],
     "slug": "get-em",
     "_migration": {
-      "version": 0.932,
-      "lastMigration": null,
+      "version": 0.935,
       "previous": {
-        "schema": 0.925,
-        "foundry": "12.330",
-        "system": "6.1.2"
+        "schema": 0.932,
+        "foundry": "12.331",
+        "system": "6.11.1"
       }
     },
     "traits": {
@@ -60,11 +61,11 @@
   "flags": {},
   "_stats": {
     "systemId": "pf2e",
-    "systemVersion": "6.2.0",
-    "coreVersion": "12.330",
+    "systemVersion": "6.11.1",
+    "coreVersion": "12.331",
     "createdTime": 1712004671684,
-    "modifiedTime": 1722568778532,
-    "lastModifiedBy": "qA45GVv5hySaf9b5",
+    "modifiedTime": 1744784991594,
+    "lastModifiedBy": "fLrrEyu988kalUMX",
     "compendiumSource": null,
     "duplicateSource": null
   },

--- a/packs/conditions/Effect__Get__Em___Lead_by_Example__YJULfanyolMqCsFD.json
+++ b/packs/conditions/Effect__Get__Em___Lead_by_Example__YJULfanyolMqCsFD.json
@@ -5,7 +5,7 @@
   "system": {
     "description": {
       "gm": "",
-      "value": "<p>Ephermeral effect.</p><p>If you attack the target you select before the end of your turn, you reveal a weak point in your foe's defenses. You gain a circumstance bonus to damage rolls against the target equal to 1 + half your Charisma modifier, and your allies gain a +1 circumstance bonus to damage rolls against the target. As your envoy level increases, so does this damage. Increase the damage by 1 at 5th, 10th, 15th, and 20th levels.</p>"
+      "value": "<p>Ephemeral effect.</p><p>If you attack the target you select before the end of your turn, you reveal a weak point in your foe's defenses. You gain a circumstance bonus to damage rolls against the target equal to 1 + half your Charisma modifier, and your allies gain a +1 circumstance bonus to damage rolls against the target. As your envoy level increases, so does this damage. Increase the damage by 1 at 5th, 10th, 15th, and 20th levels.</p>"
     },
     "rules": [
       {

--- a/packs/conditions/Effect__Mark_rUhMP1E6eS0PMSBG.json
+++ b/packs/conditions/Effect__Mark_rUhMP1E6eS0PMSBG.json
@@ -5,7 +5,7 @@
   "system": {
     "description": {
       "gm": "",
-      "value": "<p>Ephermeral effect for the marked target.</p>"
+      "value": "<p>Ephemeral effect for the marked target.</p>"
     },
     "rules": [
       {

--- a/packs/conditions/Effect__Mobile_Aim__Ephemeral__B8kDmWVlRX1uJb1o.json
+++ b/packs/conditions/Effect__Mobile_Aim__Ephemeral__B8kDmWVlRX1uJb1o.json
@@ -16,7 +16,7 @@
         "selector": "ac"
       }
     ],
-    "slug": null,
+    "slug": "effect-mobile-aim-ephemeral",
     "_migration": {
       "version": 0.932,
       "lastMigration": null


### PR DESCRIPTION
Replaced `slug` with `predicate` in Get 'Em! action.
`slug` breaks when the Ephemeral Effect's name is translated (it doesn't try to match with EE's slug, but with EE's sluggified name, which is apparently not an error, see https://github.com/foundryvtt/pf2e/issues/18812).
