### PR TITLE
Change Area / Auto Fire to use `attackItemBonus` flag for the item bonus

### DIFF
--- a/scripts/actions/area-fire.mjs
+++ b/scripts/actions/area-fire.mjs
@@ -146,7 +146,7 @@ function calculateSaveDC(weapon) {
     const ModifierPF2e = game.pf2e.Modifier;
     const actor = weapon.actor;
     const classDC = actor.getStatistic("class");
-    const itemBonus = new ModifierPF2e({ label: "Tracking Bonus", type: "item", modifier: weapon.system.runes.potency });
+    const itemBonus = new ModifierPF2e({ label: "Tracking Bonus", type: "item", modifier: weapon.flags.pf2e.attackItemBonus });
     return classDC.extend({ modifiers: itemBonus.modifier ? [itemBonus] : [] });
 }
 


### PR DESCRIPTION
As the title says.
`attackItemBonus` is where all the potency-esque item bonuses go, basically, so Area / Auto Fire might as well use it.