### PR TITLE
Fix module.json referring to the wrong zip file

### DIFF
--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
     "title": "Starfinder 2nd Edition Playtest for PF2e",
     "url": "https://github.com/TikaelSol/starfinder-field-test",
     "manifest": "https://github.com/TikaelSol/starfinder-field-test/releases/latest/download/module.json",
-    "download": "https://github.com/TikaelSol/starfinder-field-test/releases/latest/download/starfinder-field-test-for-pf2e.zip",
+    "download": "https://github.com/TikaelSol/starfinder-field-test/releases/latest/download/module.zip",
     "version": "6.8",
     "compatibility": {
         "minimum": "12.331",


### PR DESCRIPTION
Fixes Starfinder2e Playtest Deluxe Adventure module by proxy. But it really should refer to the latest releases and not the github repo.