### PR TITLE
Quality of Life Improvements for Quantum Field, and Automation for Quantum Aura

### DIFF
--- a/packs/class-features/Analyst_RLToUc8CVskgLZWJ.json
+++ b/packs/class-features/Analyst_RLToUc8CVskgLZWJ.json
@@ -56,6 +56,20 @@
             "text": "@UUID[Compendium.starfinder-field-test-for-pf2e.spells.Item.1EdpI4R98yuHhi4z]"
           }
         ]
+      },
+      {
+        "itemType": "action",
+        "key": "ItemAlteration",
+        "mode": "add",
+        "predicate": [
+          "item:slug:warp-reality"
+        ],
+        "property": "description",
+        "value": [
+          {
+            "text": "SF2E.SpecificRule.Witchwarper.Paradox.Analyst.QuantumField"
+          }
+        ]
       }
     ],
     "slug": "analyst",
@@ -101,9 +115,10 @@
   "_stats": {
     "compendiumSource": null,
     "duplicateSource": null,
-    "coreVersion": "12.331",
+    "coreVersion": "13.345",
     "systemId": "pf2e",
-    "systemVersion": "6.1.2"
+    "systemVersion": "7.2.0",
+    "exportSource": null
   },
   "sort": 7500000,
   "ownership": {

--- a/packs/class-features/Anomaly_ttsu0MLrAgQjdVbT.json
+++ b/packs/class-features/Anomaly_ttsu0MLrAgQjdVbT.json
@@ -56,6 +56,20 @@
             "text": "@UUID[Compendium.starfinder-field-test-for-pf2e.spells.Item.BoiLJzgHsyRI7N6p]"
           }
         ]
+      },
+      {
+        "itemType": "action",
+        "key": "ItemAlteration",
+        "mode": "add",
+        "predicate": [
+          "item:slug:warp-reality"
+        ],
+        "property": "description",
+        "value": [
+          {
+            "text": "SF2E.SpecificRule.Witchwarper.Paradox.Anomaly.QuantumField"
+          }
+        ]
       }
     ],
     "slug": "anomaly",
@@ -100,9 +114,10 @@
   "_stats": {
     "compendiumSource": null,
     "duplicateSource": null,
-    "coreVersion": "12.331",
+    "coreVersion": "13.345",
     "systemId": "pf2e",
-    "systemVersion": "6.1.2"
+    "systemVersion": "7.2.0",
+    "exportSource": null
   },
   "_id": "ttsu0MLrAgQjdVbT",
   "sort": 9200000,

--- a/packs/class-features/Gap_Influenced_fQRiPpFybICoKXsj.json
+++ b/packs/class-features/Gap_Influenced_fQRiPpFybICoKXsj.json
@@ -56,6 +56,20 @@
             "text": "@UUID[Compendium.starfinder-field-test-for-pf2e.spells.Item.z4tEoxGxNlgMzIQs]"
           }
         ]
+      },
+      {
+        "itemType": "action",
+        "key": "ItemAlteration",
+        "mode": "add",
+        "predicate": [
+          "item:slug:warp-reality"
+        ],
+        "property": "description",
+        "value": [
+          {
+            "text": "SF2E.SpecificRule.Witchwarper.Paradox.GapInfluenced.QuantumField"
+          }
+        ]
       }
     ],
     "slug": "gap-influenced",
@@ -100,9 +114,10 @@
   "_stats": {
     "compendiumSource": null,
     "duplicateSource": null,
-    "coreVersion": "12.331",
+    "coreVersion": "13.345",
     "systemId": "pf2e",
-    "systemVersion": "6.1.2"
+    "systemVersion": "7.2.0",
+    "exportSource": null
   },
   "_id": "fQRiPpFybICoKXsj",
   "sort": 8300000,

--- a/packs/class-features/Precog_N24ZQO1ZpMfTm23z.json
+++ b/packs/class-features/Precog_N24ZQO1ZpMfTm23z.json
@@ -56,6 +56,20 @@
             "text": "@UUID[Compendium.starfinder-field-test-for-pf2e.spells.Item.aeLOas6xxoPYjKOU]"
           }
         ]
+      },
+      {
+        "itemType": "action",
+        "key": "ItemAlteration",
+        "mode": "add",
+        "predicate": [
+          "item:slug:warp-reality"
+        ],
+        "property": "description",
+        "value": [
+          {
+            "text": "SF2E.SpecificRule.Witchwarper.Paradox.Precog.QuantumField"
+          }
+        ]
       }
     ],
     "slug": "precog",
@@ -100,9 +114,10 @@
   "_stats": {
     "compendiumSource": null,
     "duplicateSource": null,
-    "coreVersion": "12.331",
+    "coreVersion": "13.345",
     "systemId": "pf2e",
-    "systemVersion": "6.1.2"
+    "systemVersion": "7.2.0",
+    "exportSource": null
   },
   "_id": "N24ZQO1ZpMfTm23z",
   "sort": 7300000,

--- a/packs/conditions/Effect__Quantum_Aura_j6USFHjcfObXnPpg.json
+++ b/packs/conditions/Effect__Quantum_Aura_j6USFHjcfObXnPpg.json
@@ -1,0 +1,104 @@
+{
+  "name": "Effect: Quantum Aura",
+  "type": "effect",
+  "effects": [],
+  "system": {
+    "_migration": {
+      "version": 0.94,
+      "previous": null
+    },
+    "description": {
+      "value": "<p>Each time you use Warp Reality to activate your quantum field, you can choose for your quantum field to be an aura around you that moves with you. If you do, your Warp Reality action gains the aura trait and the quantum field you create is a 10-foot-radius emanation targeting you.</p>",
+      "gm": ""
+    },
+    "publication": {
+      "title": "Starfinder Second Edition Playtest Rulebook",
+      "authors": "",
+      "license": "ORC",
+      "remaster": true
+    },
+    "rules": [
+      {
+        "key": "Aura",
+        "radius": {
+          "brackets": [
+            {
+              "start": 1,
+              "end": 2,
+              "value": "@item.badge.value * 10"
+            },
+            {
+              "start": 3,
+              "end": 10,
+              "value": "10 + @item.badge.value * 5"
+            }
+          ],
+          "field": "item|badge.value"
+        },
+        "traits": [],
+        "effects": []
+      }
+    ],
+    "slug": "effect-quantum-aura",
+    "traits": {
+      "otherTags": [],
+      "value": []
+    },
+    "level": {
+      "value": 1
+    },
+    "duration": {
+      "value": -1,
+      "unit": "unlimited",
+      "expiry": null,
+      "sustained": true
+    },
+    "tokenIcon": {
+      "show": true
+    },
+    "unidentified": false,
+    "start": {
+      "value": 0,
+      "initiative": null
+    },
+    "badge": {
+      "type": "counter",
+      "value": 1,
+      "loop": false,
+      "min": null,
+      "max": null,
+      "labels": [
+        "10 ft.",
+        "20 ft.",
+        "25 ft.",
+        "30 ft.",
+        "35 ft.",
+        "40 ft.",
+        "45 ft.",
+        "50 ft.",
+        "55 ft.",
+        "60 ft."
+      ]
+    },
+    "fromSpell": false,
+    "context": null
+  },
+  "_id": "j6USFHjcfObXnPpg",
+  "img": "modules/starfinder-field-test-for-pf2e/art/icons/abilities/blue%20galaxy.webp",
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "kFKtt3r5Xd5l6LFK": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.345",
+    "systemId": "pf2e",
+    "systemVersion": "7.2.0"
+  },
+  "_key": "!items!j6USFHjcfObXnPpg"
+}

--- a/packs/feats/Quantum_Aura_qE9FlxAveWRvWxNo.json
+++ b/packs/feats/Quantum_Aura_qE9FlxAveWRvWxNo.json
@@ -6,9 +6,24 @@
   "system": {
     "description": {
       "gm": "",
-      "value": "<p>Each time you use Warp Reality to activate your quantum field, you can choose for your quantum field to be an aura around you that moves with you. If you do, your Warp Reality action gains the aura trait and the quantum field you create is a 10-foot-radius emanation targeting you.</p>"
+      "value": "<p>Each time you use Warp Reality to activate your quantum field, you can choose for your quantum field to be an aura around you that moves with you. If you do, your Warp Reality action gains the aura trait and the quantum field you create is a 10-foot-radius emanation targeting you.</p><p>@UUID[Compendium.starfinder-field-test-for-pf2e.conditions.Item.j6USFHjcfObXnPpg]{Effect: Quantum Aura}</p>"
     },
-    "rules": [],
+    "rules": [
+      {
+        "itemType": "action",
+        "key": "ItemAlteration",
+        "mode": "add",
+        "predicate": [
+          "item:slug:warp-reality"
+        ],
+        "property": "description",
+        "value": [
+          {
+            "text": "{item|description}"
+          }
+        ]
+      }
+    ],
     "slug": "quantum-aura",
     "_migration": {
       "version": 0.932,
@@ -55,9 +70,10 @@
   "_stats": {
     "compendiumSource": null,
     "duplicateSource": null,
-    "coreVersion": "12.330",
+    "coreVersion": "13.345",
     "systemId": "pf2e",
-    "systemVersion": "6.1.2"
+    "systemVersion": "7.2.0",
+    "exportSource": null
   },
   "sort": 20100000,
   "ownership": {

--- a/packs/feats/Share_Quantum_Aura_Bzc4dsAEdKMjz774.json
+++ b/packs/feats/Share_Quantum_Aura_Bzc4dsAEdKMjz774.json
@@ -6,7 +6,7 @@
   "system": {
     "description": {
       "gm": "",
-      "value": "<p><strong>Frequency</strong> once every 10 minutes</p><hr /><p>You temporarily share your quantum field with an ally. You cause your quantum field to emanate from an ally you can see instead of yourself. The ally gains all the benefits of your quantum field, and your warp spells originate from your ally instead of you until your quantum field deactivates. If you cast warp spells at other targets, you must still have line of sight to the target, but the spell originates from your ally for purposes of determining its range and line of effect.</p>"
+      "value": "<p><strong>Frequency</strong> once every 10 minutes</p><hr /><p>You temporarily share your quantum field with an ally. You cause your quantum field to emanate from an ally you can see instead of yourself. The ally gains all the benefits of your quantum field, and your warp spells originate from your ally instead of you until your quantum field deactivates. If you cast warp spells at other targets, you must still have line of sight to the target, but the spell originates from your ally for purposes of determining its range and line of effect.</p><p>@UUID[Compendium.starfinder-field-test-for-pf2e.conditions.Item.j6USFHjcfObXnPpg]{Effect: Quantum Aura}</p>"
     },
     "rules": [],
     "slug": "share-quantum-aura",
@@ -62,9 +62,10 @@
   "_stats": {
     "compendiumSource": null,
     "duplicateSource": null,
-    "coreVersion": "12.330",
+    "coreVersion": "13.345",
     "systemId": "pf2e",
-    "systemVersion": "6.1.2"
+    "systemVersion": "7.2.0",
+    "exportSource": null
   },
   "sort": 4400000,
   "ownership": {


### PR DESCRIPTION
Should make it easier to track the effects of the Witchwarper's quantum field which changes depending on their subclass. Also implements Quantum Aura feat with an aura effect that can be expanded so it's compatible with Enlarge Quantum Field feat, and shared with the Share Quantum Aura feat. Cannot automate enlarging a regular burst radius Quantum Field however because that uses a template rather than an aura.