### PR TITLE
Change from `img` to `div` to fix double logo

### DIFF
--- a/styles/dark.css
+++ b/styles/dark.css
@@ -427,20 +427,10 @@
                         color: var(--c-primary);
                     }
                 }
-                /* .shield-stats {
-          float: right;
-          position: relative;
-          bottom: 0;
-        }
-        .shield-max-status {
-          float: right;
-          position: relative;
-          top: 0;
-        } */
             }
         }
 
-        img.logo {
+        div.logo {
             display: none;
         }
     }

--- a/styles/high-contrast.css
+++ b/styles/high-contrast.css
@@ -936,7 +936,7 @@
             }
         }
 
-        img.logo {
+        div.logo {
             display: none;
         }
     }

--- a/styles/light.css
+++ b/styles/light.css
@@ -249,7 +249,7 @@
             }
         }
 
-        img.logo {
+        div.logo {
             display: none;
         }
     }


### PR DESCRIPTION
Fixes the double logo bug.

Looks like in pf2e the original `img` element was changed to a `div`, so I just updated the css files to reflect that.

Resolves #298 